### PR TITLE
feat(4870): support DateTime64 param types in expressions

### DIFF
--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -916,7 +916,6 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
       _ -> "DateTime"
     end
   end
-  defp param_type(%DateTime{}), do: "DateTime"
   defp param_type(%Date{}), do: "Date"
 
   defp param_type(%Decimal{exp: exp}) do

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -910,7 +910,7 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   defp param_type(%NaiveDateTime{}), do: "DateTime"
   defp param_type(%DateTime{microsecond: microsecond}) do
     case microsecond do
-      {microsecond, precision} when microsecond > 0 ->
+      {_val, precision} when precision > 0 ->
         "DateTime64"
 
       _ -> "DateTime"

--- a/lib/ecto/adapters/clickhouse/connection.ex
+++ b/lib/ecto/adapters/clickhouse/connection.ex
@@ -906,8 +906,16 @@ defmodule Ecto.Adapters.ClickHouse.Connection do
   defp param_type(f) when is_float(f), do: "Float64"
   defp param_type(b) when is_boolean(b), do: "Bool"
 
-  # TODO DateTime64 and Date32
+  # TODO Date32
   defp param_type(%NaiveDateTime{}), do: "DateTime"
+  defp param_type(%DateTime{microsecond: microsecond}) do
+    case microsecond do
+      {microsecond, precision} when microsecond > 0 ->
+        "DateTime64"
+
+      _ -> "DateTime"
+    end
+  end
   defp param_type(%DateTime{}), do: "DateTime"
   defp param_type(%Date{}), do: "Date"
 

--- a/test/ecto/adapters/clickhouse/connection_test.exs
+++ b/test/ecto/adapters/clickhouse/connection_test.exs
@@ -2683,7 +2683,7 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
   end
 
   test "build_params/3" do
-    params = [1, "a", true, Date.utc_today(), DateTime.utc_now()]
+    params = [1, "a", true, Date.utc_today(), DateTime.utc_now(), DateTime.utc_now() |> DateTime.truncate(:second)]
 
     assert to_string(Connection.build_params(_ix = 0, _len = 0, params)) == ""
     assert to_string(Connection.build_params(_ix = 1, _len = 0, params)) == ""
@@ -2708,12 +2708,15 @@ defmodule Ecto.Adapters.ClickHouse.ConnectionTest do
              "{$2:Bool},{$3:Date}"
 
     assert to_string(Connection.build_params(_ix = 2, _len = 3, params)) ==
-             "{$2:Bool},{$3:Date},{$4:DateTime}"
+             "{$2:Bool},{$3:Date},{$4:DateTime64}"
 
     assert to_string(Connection.build_params(_ix = 1, _len = 4, params)) ==
-             "{$1:String},{$2:Bool},{$3:Date},{$4:DateTime}"
+             "{$1:String},{$2:Bool},{$3:Date},{$4:DateTime64}"
 
     assert to_string(Connection.build_params(_ix = 0, _len = 5, params)) ==
-             "{$0:Int64},{$1:String},{$2:Bool},{$3:Date},{$4:DateTime}"
+             "{$0:Int64},{$1:String},{$2:Bool},{$3:Date},{$4:DateTime64}"
+
+    assert to_string(Connection.build_params(_ix = 0, _len = 6, params)) ==
+             "{$0:Int64},{$1:String},{$2:Bool},{$3:Date},{$4:DateTime64},{$5:DateTime}"
   end
 end


### PR DESCRIPTION
This PR fixes a bug we encountered where queries containing elixir `DateTime` params with sub-second granularity failed with `DB::Exception` errors.

I believe this bug is caused because the `ch` driver (reasonably) encodes these `DateTime`s to floats, but the `ecto_ch` adapter casts them to clickhouse's `DateTime` type rather than `DateTime64`. Only `DateTime64` can parse floats.

The fix mirrors the [ch driver's encoding logic](https://github.com/plausible/ch/blob/3b49063174b5327a711bf318f36f54fbb915c0f7/lib/ch/query.ex#L204-L215).

A workaround would be to truncate all DateTime query values to `:second` in our app, but I think we need support for sub-second times as we use timestamps as pagination cursors.

Note: we only encountered this issue with read queries. Inserts for `DateTime`s with subsecond timestamps work fine.

Here's a redacted example query log before the fix:

```
[debug] QUERY ERROR source="api_logs" db=2.7ms idle=1921.4ms
SELECT ... FROM "api_logs" AS a0 WHERE ... AND (a0."inserted_at" >= {$1:DateTime}) AND (a0."inserted_at" < {$2:DateTime}) ORDER BY a0."inserted_at" DESC LIMIT {$3:Int64} [..., ~U[2023-11-13 22:19:05.146974Z], ~U[2023-12-13 22:19:05.146974Z], 26] 

** (exit) an exception was raised:
    ** (Ch.Error) Code: 457. DB::Exception: Value 1699913983.533782 cannot be parsed as DateTime for query parameter '$1' because it isn't parsed completely: only 10 of 17 bytes was parsed: 1699913983. (BAD_QUERY_PARAMETER) (version 23.9.6.20 (official build))
```

And here's an example with the patch in place
```
[debug] QUERY OK source="api_logs" db=6.2ms decode=0.2ms idle=1783.0ms
SELECT ... FROM "api_logs" AS a0 WHERE ... AND (a0."inserted_at" >= {$1:DateTime64}) AND (a0."inserted_at" < {$2:DateTime64}) ORDER BY a0."inserted_at" DESC LIMIT {$3:Int64} [..., ~U[2023-11-13 22:21:36.779992Z], ~U[2023-12-13 22:21:36.779992Z], 26] 
```

I briefly looked into adding tests but I think I'll need guidance from the repo maintainer on the best way to add tests. My plan is to merge without additional tests, point our application at this fork, then open a PR upstream and start a conversation with the repo maintainer(s).

### Reference:
- https://clickhouse.com/docs/en/sql-reference/data-types/datetime64
- https://clickhouse.com/docs/en/sql-reference/data-types/datetime